### PR TITLE
updates location of erldis

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {deps, [{mochiweb, "\.*", {git, "git://github.com/mochi/mochiweb.git", "master"}},
-        {erldis, "\.*", {git, "git://github.com/inaka/erldis.git", "master"}},
+        {erldis, "\.*", {git, "git://github.com/japerk/erldis.git", "master"}},
         {elog, "\.*", {git, "git://github.com/inaka/elog.git", "master"}}]}.
 {require_otp_vsn, "R1[45]"}.
 {erl_opts, [{src_dirs, ["src", "tests"]},


### PR DESCRIPTION
git://github.com/inaka/erldis.git is not publicly accessible. Changed to git://github.com/japerk/erldis.git
